### PR TITLE
Add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ src/test/data/sandbox/
 # MacOS custom attributes files created by Finder
 .DS_Store
 docs/_site/
+
+# Ruby config files for local Jekyll server
+docs/.ruby-version


### PR DESCRIPTION
`.ruby-version` is used by `rbenv` to load a specific version of `ruby` for a local Jekyll server.

Other developers might run into issues with this specific `ruby` version.

Thus, let's add it to the `.gitignore` so they can use a different `ruby` version or even an entirely different `ruby` version manager other than `rbenv`.