### PR TITLE
Add internship application stage attribute to internship class

### DIFF
--- a/src/main/java/seedu/workbook/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/workbook/logic/commands/AddCommand.java
@@ -5,6 +5,7 @@ import static seedu.workbook.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.workbook.logic.parser.CliSyntax.PREFIX_STAGE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.workbook.logic.commands.exceptions.CommandException;
@@ -24,12 +25,14 @@ public class AddCommand extends Command {
             + PREFIX_ROLE + "ROLE "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_STAGE + "STAGE "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_COMPANY + "Meta "
             + PREFIX_ROLE + "Software Engineer "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_STAGE + "Interview "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/workbook/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/workbook/logic/commands/EditCommand.java
@@ -5,6 +5,7 @@ import static seedu.workbook.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.workbook.logic.parser.CliSyntax.PREFIX_STAGE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.workbook.model.Model.PREDICATE_SHOW_ALL_INTERNSHIPS;
 
@@ -24,6 +25,7 @@ import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Internship;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 
 /**
@@ -41,6 +43,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_ROLE + "ROLE] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_STAGE + "STAGE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -98,9 +101,10 @@ public class EditCommand extends Command {
         Role updatedRole = editInternshipDescriptor.getRole().orElse(internshipToEdit.getRole());
         Phone updatedPhone = editInternshipDescriptor.getPhone().orElse(internshipToEdit.getPhone());
         Email updatedEmail = editInternshipDescriptor.getEmail().orElse(internshipToEdit.getEmail());
+        Stage updatedStage = editInternshipDescriptor.getStage().orElse(internshipToEdit.getStage());
         Set<Tag> updatedTags = editInternshipDescriptor.getTags().orElse(internshipToEdit.getTags());
 
-        return new Internship(updatedCompany, updatedRole, updatedPhone, updatedEmail, updatedTags);
+        return new Internship(updatedCompany, updatedRole, updatedPhone, updatedEmail, updatedStage, updatedTags);
     }
 
     @Override
@@ -130,6 +134,7 @@ public class EditCommand extends Command {
         private Role role;
         private Phone phone;
         private Email email;
+        private Stage stage;
         private Set<Tag> tags;
 
         public EditInternshipDescriptor() {
@@ -144,6 +149,7 @@ public class EditCommand extends Command {
             setRole(toCopy.role);
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
+            setStage(toCopy.stage);
             setTags(toCopy.tags);
         }
 
@@ -151,7 +157,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(company, role, phone, email, tags);
+            return CollectionUtil.isAnyNonNull(company, role, phone, email, stage, tags);
         }
 
         public void setCompany(Company company) {
@@ -184,6 +190,13 @@ public class EditCommand extends Command {
 
         public Optional<Email> getEmail() {
             return Optional.ofNullable(email);
+        }
+        public void setStage(Stage stage) {
+            this.stage = stage;
+        }
+
+        public Optional<Stage> getStage() {
+            return Optional.ofNullable(stage);
         }
 
 
@@ -223,6 +236,7 @@ public class EditCommand extends Command {
                     && getRole().equals(e.getRole())
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
+                    && getStage().equals(e.getStage())
                     && getTags().equals(e.getTags());
         }
     }

--- a/src/main/java/seedu/workbook/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/workbook/logic/parser/AddCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.workbook.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.workbook.logic.parser.CliSyntax.PREFIX_STAGE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -17,6 +18,7 @@ import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Internship;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 
 /**
@@ -32,9 +34,9 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COMPANY, PREFIX_ROLE, PREFIX_PHONE,
-                PREFIX_EMAIL, PREFIX_TAG);
+                PREFIX_EMAIL, PREFIX_STAGE, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY, PREFIX_ROLE, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_COMPANY, PREFIX_ROLE, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_STAGE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -43,9 +45,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        Stage stage = ParserUtil.parseStage(argMultimap.getValue(PREFIX_STAGE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Internship internship = new Internship(company, role, phone, email, tagList);
+        Internship internship = new Internship(company, role, phone, email, stage, tagList);
 
         return new AddCommand(internship);
     }

--- a/src/main/java/seedu/workbook/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/workbook/logic/parser/CliSyntax.java
@@ -10,6 +10,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_ROLE = new Prefix("r/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
+    public static final Prefix PREFIX_STAGE = new Prefix("s/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/workbook/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/workbook/logic/parser/EditCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.workbook.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.workbook.logic.parser.CliSyntax.PREFIX_STAGE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -33,7 +34,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COMPANY, PREFIX_ROLE, PREFIX_PHONE,
-                PREFIX_EMAIL, PREFIX_TAG);
+                PREFIX_EMAIL, PREFIX_STAGE, PREFIX_TAG);
 
         Index index;
 
@@ -55,6 +56,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             editInternshipDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+        if (argMultimap.getValue(PREFIX_STAGE).isPresent()) {
+            editInternshipDescriptor.setStage(ParserUtil.parseStage(argMultimap.getValue(PREFIX_STAGE).get()));
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editInternshipDescriptor::setTags);

--- a/src/main/java/seedu/workbook/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/workbook/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import seedu.workbook.model.internship.Company;
 import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 
 /**
@@ -95,6 +96,21 @@ public class ParserUtil {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
+    }
+
+    /**
+     * Parses a {@code String stage} into an {@code Stage}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code stage} is invalid.
+     */
+    public static Stage parseStage(String stage) throws ParseException {
+        requireNonNull(stage);
+        String trimmedStage = stage.trim();
+        if (!Stage.isValidStage(trimmedStage)) {
+            throw new ParseException(Stage.MESSAGE_CONSTRAINTS);
+        }
+        return new Stage(trimmedStage);
     }
 
     /**

--- a/src/main/java/seedu/workbook/model/internship/Internship.java
+++ b/src/main/java/seedu/workbook/model/internship/Internship.java
@@ -20,6 +20,7 @@ public class Internship {
     private final Role role;
     private final Phone phone;
     private final Email email;
+    private final Stage stage;
 
     // Data fields
 
@@ -28,12 +29,13 @@ public class Internship {
     /**
      * Every field must be present and not null.
      */
-    public Internship(Company company, Role role, Phone phone, Email email, Set<Tag> tags) {
-        requireAllNonNull(company, role, phone, email, tags);
+    public Internship(Company company, Role role, Phone phone, Email email, Stage stage, Set<Tag> tags) {
+        requireAllNonNull(company, role, phone, email, stage, tags);
         this.company = company;
         this.role = role;
         this.phone = phone;
         this.email = email;
+        this.stage = stage;
         this.tags.addAll(tags);
     }
 
@@ -51,6 +53,9 @@ public class Internship {
 
     public Email getEmail() {
         return email;
+    }
+    public Stage getStage() {
+        return stage;
     }
 
 
@@ -95,13 +100,14 @@ public class Internship {
                 && otherInternship.getRole().equals(getRole())
                 && otherInternship.getPhone().equals(getPhone())
                 && otherInternship.getEmail().equals(getEmail())
+                && otherInternship.getStage().equals(getStage())
                 && otherInternship.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(company, role, phone, email, tags);
+        return Objects.hash(company, role, phone, email, stage, tags);
     }
 
     @Override
@@ -113,7 +119,9 @@ public class Internship {
                 .append("; Phone: ")
                 .append(getPhone())
                 .append("; Email: ")
-                .append(getEmail());
+                .append(getEmail())
+                .append("; Stage: ")
+                .append(getStage());
 
 
         Set<Tag> tags = getTags();

--- a/src/main/java/seedu/workbook/model/internship/Stage.java
+++ b/src/main/java/seedu/workbook/model/internship/Stage.java
@@ -1,0 +1,59 @@
+package seedu.workbook.model.internship;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.workbook.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents an Internship's application stage in WorkBook.
+ * Guarantees: immutable; is valid as declared in {@link #isValidStage(String)}
+ */
+public class Stage {
+
+    // CHECKSTYLE.OFF: LineLength
+    public static final String MESSAGE_CONSTRAINTS = "Stage should only contain alphanumeric characters and spaces, and it should not be blank";
+    // CHECKSTYLE.ON: LineLength
+
+    /*
+     * The first character of the Stage must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String value;
+
+    /**
+     * Constructs a {@code Stage}.
+     *
+     * @param stage A valid Stage name.
+     */
+    public Stage(String stage) {
+        requireNonNull(stage);
+        checkArgument(isValidStage(stage), MESSAGE_CONSTRAINTS);
+        value = stage;
+    }
+
+    /**
+     * Returns true if a given string is a valid stage.
+     */
+    public static boolean isValidStage(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Stage // instanceof handles nulls
+                && value.equals(((Stage) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/workbook/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/workbook/model/util/SampleDataUtil.java
@@ -11,6 +11,7 @@ import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Internship;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 
 /**
@@ -24,36 +25,42 @@ public class SampleDataUtil {
                 new Role("Software Engineer"),
                 new Phone("87438807"),
                 new Email("alexyeoh@example.com"),
+                new Stage("HR Interview"),
                 getTagSet("friends")),
             new Internship(
                 new Company("Hudson River Trading"),
                 new Role("Algorithm Engineer"),
                 new Phone("99272758"),
                 new Email("berniceyu@example.com"),
+                new Stage("Team Lead Interview"),
                 getTagSet("colleagues", "friends")),
             new Internship(
                 new Company("Shopee"),
                 new Role("iOS Engineer"),
                 new Phone("93210283"),
                 new Email("charlotte@example.com"),
+                new Stage("Online Coding Assessment"),
                 getTagSet("neighbours")),
             new Internship(
                 new Company("Visa"),
                 new Role("Backend Engineer"),
                 new Phone("91031282"),
                 new Email("lidavid@example.com"),
+                new Stage("Technical Interview"),
                 getTagSet("family")),
             new Internship(
                 new Company("Binance"),
                 new Role("Blockchain Engineer"),
                 new Phone("92492021"),
                 new Email("irfan@example.com"),
+                new Stage("Application Sent"),
                 getTagSet("classmates")),
             new Internship(
                 new Company("Optiver"),
                 new Role("God Engineer"),
                 new Phone("92624417"),
                 new Email("royb@example.com"),
+                new Stage("Rejected"),
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/workbook/storage/JsonAdaptedInternship.java
+++ b/src/main/java/seedu/workbook/storage/JsonAdaptedInternship.java
@@ -15,6 +15,7 @@ import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Internship;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 
 /**
@@ -28,6 +29,7 @@ class JsonAdaptedInternship {
     private final String role;
     private final String phone;
     private final String email;
+    private final String stage;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -37,11 +39,13 @@ class JsonAdaptedInternship {
     public JsonAdaptedInternship(@JsonProperty("company") String company, @JsonProperty("role") String role,
             @JsonProperty("phone") String phone,
             @JsonProperty("email") String email,
+            @JsonProperty("stage") String stage,
             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.company = company;
         this.role = role;
         this.phone = phone;
         this.email = email;
+        this.stage = stage;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -55,6 +59,7 @@ class JsonAdaptedInternship {
         role = source.getRole().value;
         phone = source.getPhone().value;
         email = source.getEmail().value;
+        stage = source.getStage().value;
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -105,10 +110,18 @@ class JsonAdaptedInternship {
         }
         final Email modelEmail = new Email(email);
 
+        if (stage == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Stage.class.getSimpleName()));
+        }
+        if (!Stage.isValidStage(stage)) {
+            throw new IllegalValueException(Stage.MESSAGE_CONSTRAINTS);
+        }
+        final Stage modelStage = new Stage(stage);
+
 
 
         final Set<Tag> modelTags = new HashSet<>(internshipTags);
-        return new Internship(modelCompany, modelRole, modelPhone, modelEmail, modelTags);
+        return new Internship(modelCompany, modelRole, modelPhone, modelEmail, modelStage, modelTags);
     }
 
 }

--- a/src/main/java/seedu/workbook/ui/InternshipCard.java
+++ b/src/main/java/seedu/workbook/ui/InternshipCard.java
@@ -39,6 +39,8 @@ public class InternshipCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private Label stage;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -52,6 +54,7 @@ public class InternshipCard extends UiPart<Region> {
         role.setText(internship.getRole().value);
         phone.setText(internship.getPhone().value);
         email.setText(internship.getEmail().value);
+        stage.setText(internship.getStage().value);
         internship.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/InternshipListCard.fxml
+++ b/src/main/resources/view/InternshipListCard.fxml
@@ -31,6 +31,7 @@
       <Label fx:id="role" styleClass="cell_small_label" text="\$role" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="stage" styleClass="cell_small_label" text="\$stage" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableWorkBookTest/duplicateInternshipWorkBook.json
+++ b/src/test/data/JsonSerializableWorkBookTest/duplicateInternshipWorkBook.json
@@ -4,11 +4,13 @@
     "role": "Software Engineer",
     "phone": "94351253",
     "email": "alice@example.com",
+    "stage": "HR interview",
     "tagged": [ "friends" ]
   }, {
     "company": "Alice Pauline",
     "role": "Software Engineer",
     "phone": "94351253",
-    "email": "pauline@example.com"
+    "email": "pauline@example.com",
+    "stage": "Rejected"
   } ]
 }

--- a/src/test/data/JsonSerializableWorkBookTest/invalidInternshipWorkBook.json
+++ b/src/test/data/JsonSerializableWorkBookTest/invalidInternshipWorkBook.json
@@ -4,6 +4,7 @@
     "role": "Software Engineer",
     "phone": "9482424",
     "email": "invalid@email!3e",
-    "address": "4th street"
+    "address": "4th street",
+    "stage": "HR interview"
   } ]
 }

--- a/src/test/data/JsonSerializableWorkBookTest/typicalInternshipsWorkBook.json
+++ b/src/test/data/JsonSerializableWorkBookTest/typicalInternshipsWorkBook.json
@@ -5,42 +5,49 @@
     "role" : "Software Engineer",
     "phone" : "94351253",
     "email" : "alice@example.com",
+    "stage" : "Technical Interview",
     "tagged" : [ "friends" ]
   }, {
     "company" : "Benson Meier",
     "role" : "Software Engineer",
     "phone" : "98765432",
     "email" : "johnd@example.com",
+    "stage" : "HR Interview",
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "company" : "Carl Kurz",
     "role" : "Software Engineer",
     "phone" : "95352563",
     "email" : "heinz@example.com",
+    "stage" : "Rejected",
     "tagged" : [ ]
   }, {
     "company" : "Daniel Meier",
     "role" : "Software Engineer",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
+    "stage" : "Technical Interview",
     "tagged" : [ "friends" ]
   }, {
     "company" : "Elle Meyer",
     "role" : "Software Engineer",
     "phone" : "9482224",
     "email" : "werner@example.com",
+    "stage" : "Application Sent",
     "tagged" : [ ]
   }, {
     "company" : "Fiona Kunz",
     "role" : "Software Engineer",
     "phone" : "9482427",
     "email" : "lydia@example.com",
+    "stage" : "Online Assessment",
     "tagged" : [ ]
   }, {
     "company" : "George Best",
     "role" : "Software Engineer",
     "phone" : "9482442",
     "email" : "anna@example.com",
+    "stage" : "Team Lead Interview",
     "tagged" : [ ]
   } ]
 }

--- a/src/test/data/JsonWorkBookStorageTest/invalidAndValidInternshipWorkBook.json
+++ b/src/test/data/JsonWorkBookStorageTest/invalidAndValidInternshipWorkBook.json
@@ -3,10 +3,12 @@
     "company": "Valid Internship",
     "role": "Software Engineer",
     "phone": "9482424",
-    "email": "hans@example.com"
+    "email": "hans@example.com",
+    "stage": "Technical Interview"
   }, {
     "company": "Internship With Missing Role",
     "phone": "9482424",
-    "email": "hans@example.com"
+    "email": "hans@example.com",
+    "stage": "Technical Interview"
   } ]
 }

--- a/src/test/data/JsonWorkBookStorageTest/invalidInternshipWorkBook.json
+++ b/src/test/data/JsonWorkBookStorageTest/invalidInternshipWorkBook.json
@@ -3,6 +3,7 @@
     "company": "Internship with invalid company field: Ha!ns Mu@ster",
     "role": "Software Engineer",
     "phone": "9482424",
-    "email": "hans@example.com"
+    "email": "hans@example.com",
+    "stage": "Technical Interview"
   } ]
 }

--- a/src/test/java/seedu/workbook/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/workbook/logic/LogicManagerTest.java
@@ -7,6 +7,7 @@ import static seedu.workbook.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
 import static seedu.workbook.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.workbook.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.workbook.logic.commands.CommandTestUtil.ROLE_DESC_AMY;
+import static seedu.workbook.logic.commands.CommandTestUtil.STAGE_DESC_AMY;
 import static seedu.workbook.testutil.Assert.assertThrows;
 import static seedu.workbook.testutil.TypicalInternships.AMY;
 
@@ -80,7 +81,7 @@ public class LogicManagerTest {
 
         // Execute add command
         String addCommand = AddCommand.COMMAND_WORD + COMPANY_DESC_AMY + ROLE_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY;
+                + EMAIL_DESC_AMY + STAGE_DESC_AMY;
 
         Internship expectedInternship = new InternshipBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();

--- a/src/test/java/seedu/workbook/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/workbook/logic/commands/CommandTestUtil.java
@@ -6,6 +6,7 @@ import static seedu.workbook.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.workbook.logic.parser.CliSyntax.PREFIX_STAGE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.workbook.testutil.Assert.assertThrows;
 
@@ -34,6 +35,8 @@ public class CommandTestUtil {
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
+    public static final String VALID_STAGE_AMY = "Technical Interview";
+    public static final String VALID_STAGE_BOB = "HR Interview";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -45,6 +48,8 @@ public class CommandTestUtil {
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
+    public static final String STAGE_DESC_AMY = " " + PREFIX_STAGE + VALID_STAGE_AMY;
+    public static final String STAGE_DESC_BOB = " " + PREFIX_STAGE + VALID_STAGE_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -53,6 +58,7 @@ public class CommandTestUtil {
     public static final String INVALID_ROLE_DESC = " " + PREFIX_ROLE + "James&"; // '&' not allowed in roles
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_STAGE_DESC = " " + PREFIX_STAGE + "H&Interview"; // '&' not allowed in stage
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     // CHECKSTYLE.ON: LineLength
 

--- a/src/test/java/seedu/workbook/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/workbook/logic/parser/AddCommandParserTest.java
@@ -9,6 +9,7 @@ import static seedu.workbook.logic.commands.CommandTestUtil.INVALID_COMPANY_DESC
 import static seedu.workbook.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.workbook.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.workbook.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
+import static seedu.workbook.logic.commands.CommandTestUtil.INVALID_STAGE_DESC;
 import static seedu.workbook.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.workbook.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.workbook.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
@@ -16,12 +17,15 @@ import static seedu.workbook.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.workbook.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.workbook.logic.commands.CommandTestUtil.ROLE_DESC_AMY;
 import static seedu.workbook.logic.commands.CommandTestUtil.ROLE_DESC_BOB;
+import static seedu.workbook.logic.commands.CommandTestUtil.STAGE_DESC_AMY;
+import static seedu.workbook.logic.commands.CommandTestUtil.STAGE_DESC_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.workbook.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_COMPANY_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_ROLE_BOB;
+import static seedu.workbook.logic.commands.CommandTestUtil.VALID_STAGE_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.workbook.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -37,6 +41,7 @@ import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Internship;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 import seedu.workbook.testutil.InternshipBuilder;
 
@@ -50,32 +55,35 @@ public class AddCommandParserTest {
         // whitespace only preamble
         assertParseSuccess(parser,
                 PREAMBLE_WHITESPACE + COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                         + TAG_DESC_FRIEND,
+                         + STAGE_DESC_BOB + TAG_DESC_FRIEND,
                 new AddCommand(expectedInternship));
 
         // multiple company names - last company name accepted
-        assertParseSuccess(parser, COMPANY_DESC_AMY + COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                 + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
+        assertParseSuccess(parser, COMPANY_DESC_AMY + COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB
+                + EMAIL_DESC_BOB + STAGE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
 
         // multiple roles - last role accepted
         assertParseSuccess(parser, COMPANY_DESC_BOB + ROLE_DESC_AMY + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
+               + STAGE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                 + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
+                + STAGE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                 + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
+                + STAGE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
 
+        // multiple stages - last stage accepted
+        assertParseSuccess(parser, COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + STAGE_DESC_AMY + STAGE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedInternship));
 
         // multiple tags - all accepted
         Internship expectedInternshipMultipleTags = new InternshipBuilder(BOB)
                 .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         assertParseSuccess(parser, COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedInternshipMultipleTags));
+                + STAGE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedInternshipMultipleTags));
     }
 
     @Test
@@ -83,7 +91,7 @@ public class AddCommandParserTest {
         // zero tags
         Internship expectedInternship = new InternshipBuilder(AMY).withTags().build();
         assertParseSuccess(parser,
-                COMPANY_DESC_AMY + ROLE_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY,
+                COMPANY_DESC_AMY + ROLE_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + STAGE_DESC_AMY,
                 new AddCommand(expectedInternship));
     }
 
@@ -93,28 +101,33 @@ public class AddCommandParserTest {
 
         // missing company prefix
         assertParseFailure(parser,
-                VALID_COMPANY_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB,
+                VALID_COMPANY_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + STAGE_DESC_BOB,
                 expectedMessage);
 
-        // missing company prefix
+        // missing role prefix
         assertParseFailure(parser,
-                COMPANY_DESC_BOB + VALID_ROLE_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB,
+                COMPANY_DESC_BOB + VALID_ROLE_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + STAGE_DESC_BOB,
                 expectedMessage);
 
         // missing phone prefix
         assertParseFailure(parser,
-                COMPANY_DESC_BOB + ROLE_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB,
+                COMPANY_DESC_BOB + ROLE_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + STAGE_DESC_BOB,
                 expectedMessage);
 
         // missing email prefix
         assertParseFailure(parser,
-                COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB,
+                COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + STAGE_DESC_BOB,
+                expectedMessage);
+
+        // missing stage prefix
+        assertParseFailure(parser,
+                COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_STAGE_BOB,
                 expectedMessage);
 
 
         // all prefixes missing
         assertParseFailure(parser,
-                VALID_COMPANY_BOB + VALID_ROLE_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB,
+                VALID_COMPANY_BOB + VALID_ROLE_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_STAGE_BOB,
                 expectedMessage);
     }
 
@@ -122,43 +135,47 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid company
         assertParseFailure(parser,
-                INVALID_COMPANY_DESC + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                INVALID_COMPANY_DESC + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + STAGE_DESC_BOB
                         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Company.MESSAGE_CONSTRAINTS);
 
         // invalid role
         assertParseFailure(parser,
-                COMPANY_DESC_BOB + INVALID_ROLE_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                COMPANY_DESC_BOB + INVALID_ROLE_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + STAGE_DESC_BOB
                         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Role.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser,
-                COMPANY_DESC_BOB + ROLE_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB
+                COMPANY_DESC_BOB + ROLE_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + STAGE_DESC_BOB
                         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser,
-                COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC
+                COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + STAGE_DESC_BOB
                         + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Email.MESSAGE_CONSTRAINTS);
 
-
+        // invalid stage
+        assertParseFailure(parser,
+                COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_STAGE_DESC
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Stage.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + STAGE_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser,
-                INVALID_COMPANY_DESC + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB,
+                INVALID_COMPANY_DESC + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + STAGE_DESC_BOB,
                 Company.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser,
                 PREAMBLE_NON_EMPTY + COMPANY_DESC_BOB + ROLE_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                        + STAGE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/workbook/storage/JsonAdaptedInternshipTest.java
+++ b/src/test/java/seedu/workbook/storage/JsonAdaptedInternshipTest.java
@@ -16,10 +16,12 @@ import seedu.workbook.model.internship.Company;
 import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 
 public class JsonAdaptedInternshipTest {
     private static final String INVALID_COMPANY = "R@chel";
     private static final String INVALID_ROLE = "R@chel";
+    private static final String INVALID_STAGE = "H@ Interview";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
@@ -28,6 +30,7 @@ public class JsonAdaptedInternshipTest {
     private static final String VALID_ROLE = BENSON.getRole().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
+    private static final String VALID_STAGE = BENSON.getStage().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -41,15 +44,15 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidCompany_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(INVALID_COMPANY, VALID_ROLE, VALID_PHONE,
-                VALID_EMAIL, VALID_TAGS);
+                VALID_EMAIL, VALID_STAGE, VALID_TAGS);
         String expectedMessage = Company.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
 
     @Test
     public void toModelType_nullCompany_throwsIllegalValueException() {
-        JsonAdaptedInternship internship = new JsonAdaptedInternship(null, VALID_ROLE, VALID_PHONE, VALID_EMAIL,
-                 VALID_TAGS);
+        JsonAdaptedInternship internship = new JsonAdaptedInternship(null, VALID_ROLE, VALID_PHONE,
+                VALID_EMAIL, VALID_STAGE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Company.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -57,7 +60,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidRole_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, INVALID_ROLE, VALID_PHONE,
-                VALID_EMAIL, VALID_TAGS);
+                VALID_STAGE, VALID_EMAIL, VALID_TAGS);
         String expectedMessage = Role.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -65,7 +68,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_nullRole_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, null, VALID_PHONE, VALID_EMAIL,
-                VALID_TAGS);
+                VALID_STAGE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Role.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -73,7 +76,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, INVALID_PHONE,
-                VALID_EMAIL, VALID_TAGS);
+                VALID_STAGE, VALID_EMAIL, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -81,7 +84,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, null, VALID_EMAIL,
-                VALID_TAGS);
+                VALID_STAGE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -89,7 +92,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, VALID_PHONE,
-                INVALID_EMAIL, VALID_TAGS);
+                INVALID_EMAIL, VALID_STAGE, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -97,19 +100,33 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, VALID_PHONE, null,
-                 VALID_TAGS);
+                VALID_STAGE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
 
+    @Test
+    public void toModelType_invalidStage_throwsIllegalValueException() {
+        JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, VALID_PHONE,
+                VALID_EMAIL, null, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Stage.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
+    }
 
+    @Test
+    public void toModelType_nullStage_throwsIllegalValueException() {
+        JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, VALID_PHONE,
+                VALID_EMAIL, INVALID_STAGE, VALID_TAGS);
+        String expectedMessage = Stage.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
+    }
 
     @Test
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, VALID_PHONE,
-                VALID_EMAIL, invalidTags);
+                VALID_EMAIL, VALID_STAGE, invalidTags);
         assertThrows(IllegalValueException.class, internship::toModelType);
     }
 

--- a/src/test/java/seedu/workbook/storage/JsonAdaptedInternshipTest.java
+++ b/src/test/java/seedu/workbook/storage/JsonAdaptedInternshipTest.java
@@ -60,7 +60,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidRole_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, INVALID_ROLE, VALID_PHONE,
-                VALID_STAGE, VALID_EMAIL, VALID_TAGS);
+                VALID_EMAIL, VALID_STAGE, VALID_TAGS);
         String expectedMessage = Role.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }
@@ -76,7 +76,7 @@ public class JsonAdaptedInternshipTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedInternship internship = new JsonAdaptedInternship(VALID_COMPANY, VALID_ROLE, INVALID_PHONE,
-                VALID_STAGE, VALID_EMAIL, VALID_TAGS);
+                VALID_EMAIL, VALID_STAGE, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, internship::toModelType);
     }

--- a/src/test/java/seedu/workbook/testutil/EditInternshipDescriptorBuilder.java
+++ b/src/test/java/seedu/workbook/testutil/EditInternshipDescriptorBuilder.java
@@ -10,6 +10,7 @@ import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Internship;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 
 /**
@@ -36,6 +37,7 @@ public class EditInternshipDescriptorBuilder {
         descriptor.setRole(internship.getRole());
         descriptor.setPhone(internship.getPhone());
         descriptor.setEmail(internship.getEmail());
+        descriptor.setStage(internship.getStage());
         descriptor.setTags(internship.getTags());
     }
 
@@ -68,6 +70,14 @@ public class EditInternshipDescriptorBuilder {
      */
     public EditInternshipDescriptorBuilder withEmail(String email) {
         descriptor.setEmail(new Email(email));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Stage} of the {@code EditInternshipDescriptor} that we are building.
+     */
+    public EditInternshipDescriptorBuilder withStage(String stage) {
+        descriptor.setStage(new Stage(stage));
         return this;
     }
 

--- a/src/test/java/seedu/workbook/testutil/InternshipBuilder.java
+++ b/src/test/java/seedu/workbook/testutil/InternshipBuilder.java
@@ -8,6 +8,7 @@ import seedu.workbook.model.internship.Email;
 import seedu.workbook.model.internship.Internship;
 import seedu.workbook.model.internship.Phone;
 import seedu.workbook.model.internship.Role;
+import seedu.workbook.model.internship.Stage;
 import seedu.workbook.model.tag.Tag;
 import seedu.workbook.model.util.SampleDataUtil;
 
@@ -20,12 +21,14 @@ public class InternshipBuilder {
     public static final String DEFAULT_ROLE = "God Developer";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
+    public static final String DEFAULT_STAGE = "HR Interview";
 
 
     private Company company;
     private Role role;
     private Phone phone;
     private Email email;
+    private Stage stage;
     private Set<Tag> tags;
 
     /**
@@ -36,6 +39,7 @@ public class InternshipBuilder {
         role = new Role(DEFAULT_ROLE);
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
+        stage = new Stage(DEFAULT_STAGE);
         tags = new HashSet<>();
     }
 
@@ -47,6 +51,7 @@ public class InternshipBuilder {
         role = internshipToCopy.getRole();
         phone = internshipToCopy.getPhone();
         email = internshipToCopy.getEmail();
+        stage = internshipToCopy.getStage();
         tags = new HashSet<>(internshipToCopy.getTags());
     }
 
@@ -91,8 +96,16 @@ public class InternshipBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Stage} of the {@code Internship} that we are building.
+     */
+    public InternshipBuilder withStage(String stage) {
+        this.stage = new Stage(stage);
+        return this;
+    }
+
     public Internship build() {
-        return new Internship(company, role, phone, email, tags);
+        return new Internship(company, role, phone, email, stage, tags);
     }
 
 }

--- a/src/test/java/seedu/workbook/testutil/InternshipUtil.java
+++ b/src/test/java/seedu/workbook/testutil/InternshipUtil.java
@@ -5,6 +5,7 @@ import static seedu.workbook.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.workbook.logic.parser.CliSyntax.PREFIX_STAGE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -35,6 +36,7 @@ public class InternshipUtil {
         sb.append(PREFIX_ROLE + internship.getRole().value + " ");
         sb.append(PREFIX_PHONE + internship.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + internship.getEmail().value + " ");
+        sb.append(PREFIX_STAGE + internship.getStage().value + " ");
         internship.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -50,6 +52,7 @@ public class InternshipUtil {
         descriptor.getRole().ifPresent(role -> sb.append(PREFIX_ROLE).append(role.value).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
+        descriptor.getStage().ifPresent(stage -> sb.append(PREFIX_STAGE).append(stage.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/workbook/testutil/TypicalInternships.java
+++ b/src/test/java/seedu/workbook/testutil/TypicalInternships.java
@@ -8,6 +8,8 @@ import static seedu.workbook.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_ROLE_AMY;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_ROLE_BOB;
+import static seedu.workbook.logic.commands.CommandTestUtil.VALID_STAGE_AMY;
+import static seedu.workbook.logic.commands.CommandTestUtil.VALID_STAGE_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
@@ -17,6 +19,7 @@ import java.util.List;
 
 import seedu.workbook.model.WorkBook;
 import seedu.workbook.model.internship.Internship;
+
 
 /**
  * A utility class containing a list of {@code Internship} objects to be used in tests.
@@ -28,40 +31,47 @@ public class TypicalInternships {
         .withRole("Software Engineer")
         .withEmail("alice@example.com")
         .withPhone("94351253")
+        .withStage("Technical Interview")
         .withTags("friends").build();
     public static final Internship BENSON = new InternshipBuilder()
         .withCompany("Benson Meier")
         .withRole("Software Engineer")
         .withEmail("johnd@example.com")
         .withPhone("98765432")
+        .withStage("HR Interview")
         .withTags("owesMoney", "friends").build();
     public static final Internship CARL = new InternshipBuilder()
         .withCompany("Carl Kurz")
         .withRole("Software Engineer")
         .withPhone("95352563")
-        .withEmail("heinz@example.com").build();
+        .withEmail("heinz@example.com")
+        .withStage("Rejected").build();
 
     public static final Internship DANIEL = new InternshipBuilder()
         .withCompany("Daniel Meier")
         .withRole("Software Engineer")
         .withPhone("87652533")
         .withEmail("cornelia@example.com")
+        .withStage("Technical Interview")
         .withTags("friends").build();
     public static final Internship ELLE = new InternshipBuilder()
         .withCompany("Elle Meyer")
         .withRole("Software Engineer")
         .withPhone("9482224")
-        .withEmail("werner@example.com").build();
+        .withEmail("werner@example.com")
+        .withStage("Application Sent").build();
     public static final Internship FIONA = new InternshipBuilder()
         .withCompany("Fiona Kunz")
         .withRole("Software Engineer")
         .withPhone("9482427")
-        .withEmail("lydia@example.com").build();
+        .withEmail("lydia@example.com")
+        .withStage("Online Assessment").build();
     public static final Internship GEORGE = new InternshipBuilder()
         .withCompany("George Best")
         .withRole("Software Engineer")
         .withPhone("9482442")
-        .withEmail("anna@example.com").build();
+        .withEmail("anna@example.com")
+        .withStage("Team Lead Interview").build();
 
 
     // Manually added
@@ -83,12 +93,14 @@ public class TypicalInternships {
         .withRole(VALID_ROLE_AMY)
         .withPhone(VALID_PHONE_AMY)
         .withEmail(VALID_EMAIL_AMY)
+        .withStage(VALID_STAGE_AMY)
         .withTags(VALID_TAG_FRIEND).build();
     public static final Internship BOB = new InternshipBuilder()
         .withCompany(VALID_COMPANY_BOB)
         .withRole(VALID_ROLE_BOB)
         .withPhone(VALID_PHONE_BOB)
         .withEmail(VALID_EMAIL_BOB)
+        .withStage(VALID_STAGE_BOB)
         .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
We want to keep track of the stage of application we are at so we know what to expect next in the application.

Let's add a new field to `AddCommand` and `EditCommand` to include `stage` attribute.

This follows the conventional way of adding and editing  an internship. As internship application is a process, allowing edits to the stage is justifiable.

Let's also edit the JUnit tests for these respective classes to reflect the changes in the main code. Respective JSON files used in testcases are updated as well.

However, not advised to follow this chunky commit method.