### PR TITLE
Add sorting by date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/main/resources/docs/
 
 # VSCode files
 /bin/
+/.vscode/
 
 # Storage/log files
 /data/

--- a/src/main/java/seedu/workbook/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/workbook/logic/commands/EditCommand.java
@@ -7,7 +7,6 @@ import static seedu.workbook.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_STAGE;
 import static seedu.workbook.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.workbook.model.Model.PREDICATE_SHOW_ALL_INTERNSHIPS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -101,7 +100,10 @@ public class EditCommand extends Command {
         }
 
         model.setInternship(internshipToEdit, editedInternship);
-        model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+        // Doesnt make sense to me to reset the filtering after editing an internship
+        // its not that hard to just type list
+
+        // model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
         model.commitWorkBook();
         return new CommandResult(String.format(MESSAGE_EDIT_INTERNSHIP_SUCCESS, editedInternship));
     }

--- a/src/main/java/seedu/workbook/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/workbook/logic/commands/ListCommand.java
@@ -16,11 +16,13 @@ public class ListCommand extends Command {
     /** Message string displaying successful execution of the list command */
     public static final String MESSAGE_SUCCESS = "Listed all internships";
 
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
+        // `list` should reset ui, showing internships in unsorted order aka the order
+        // the user added them in
+        model.resetOrder();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/workbook/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/workbook/logic/commands/SortCommand.java
@@ -1,0 +1,28 @@
+package seedu.workbook.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.workbook.model.Model;
+
+/**
+ * Sorts all internships in WorkBook by Date, with the nearest upcoming Date at
+ * the top.
+ */
+public class SortCommand extends Command {
+
+    /** Command word to execute the sort command */
+    public static final String COMMAND_WORD = "sort";
+
+    /** Message string displaying successful execution of the sort command */
+    public static final String MESSAGE_SUCCESS = "Sorted internship applications by date and time.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.sortInternshipListByDate();
+        // undo behaviour doesn't really work well for now due to how we manipulate
+        // internalList in `UniqueInternshipList.java`
+        model.commitWorkBook();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/workbook/logic/parser/WorkBookParser.java
+++ b/src/main/java/seedu/workbook/logic/parser/WorkBookParser.java
@@ -16,6 +16,7 @@ import seedu.workbook.logic.commands.FindCommand;
 import seedu.workbook.logic.commands.HelpCommand;
 import seedu.workbook.logic.commands.ListCommand;
 import seedu.workbook.logic.commands.RedoCommand;
+import seedu.workbook.logic.commands.SortCommand;
 import seedu.workbook.logic.commands.UndoCommand;
 import seedu.workbook.logic.parser.exceptions.ParseException;
 
@@ -63,6 +64,9 @@ public class WorkBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommand();
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();

--- a/src/main/java/seedu/workbook/model/Model.java
+++ b/src/main/java/seedu/workbook/model/Model.java
@@ -64,6 +64,18 @@ public interface Model {
      */
     void setInternship(Internship target, Internship editedInternship);
 
+    /**
+     * Sorts the internship list by date.
+     *
+     */
+    void sortInternshipListByDate();
+
+    /**
+     * Resets the order of the internship list to default, oldest added application at top.
+     *
+     */
+    void resetOrder();
+
     /** Returns an unmodifiable view of the filtered internship list */
     ObservableList<Internship> getFilteredInternshipList();
 

--- a/src/main/java/seedu/workbook/model/ModelManager.java
+++ b/src/main/java/seedu/workbook/model/ModelManager.java
@@ -33,7 +33,7 @@ public class ModelManager implements Model {
 
         versionedWorkBook = new VersionedWorkBook(workBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredInternships = new FilteredList<>(this.versionedWorkBook.getInternshipList());
+        filteredInternships = new FilteredList<>(this.versionedWorkBook.getUiFacingInternshipList());
     }
 
     public ModelManager() {
@@ -101,6 +101,8 @@ public class ModelManager implements Model {
     @Override
     public void addInternship(Internship internship) {
         versionedWorkBook.addInternship(internship);
+        // resets ui view to show all internships whenever add command is executed
+        // ideal behaviour TBD
         updateFilteredInternshipList(PREDICATE_SHOW_ALL_INTERNSHIPS);
     }
 
@@ -109,6 +111,16 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedInternship);
 
         versionedWorkBook.setInternship(target, editedInternship);
+    }
+
+    @Override
+    public void sortInternshipListByDate() {
+        versionedWorkBook.sortInternshipListByDate();
+    }
+
+    @Override
+    public void resetOrder() {
+        versionedWorkBook.resetOrder();
     }
 
     //=========== Filtered Internship List Accessors =============================================================

--- a/src/main/java/seedu/workbook/model/ReadOnlyWorkBook.java
+++ b/src/main/java/seedu/workbook/model/ReadOnlyWorkBook.java
@@ -12,6 +12,8 @@ public interface ReadOnlyWorkBook {
      * Returns an unmodifiable view of the internships list.
      * This list will not contain any duplicate internships.
      */
-    ObservableList<Internship> getInternshipList();
+    ObservableList<Internship> getUiFacingInternshipList();
+
+    ObservableList<Internship> getBaseInternshipList();
 
 }

--- a/src/main/java/seedu/workbook/model/WorkBook.java
+++ b/src/main/java/seedu/workbook/model/WorkBook.java
@@ -55,7 +55,7 @@ public class WorkBook implements ReadOnlyWorkBook {
     public void resetData(ReadOnlyWorkBook newData) {
         requireNonNull(newData);
 
-        setInternships(newData.getInternshipList());
+        setInternships(newData.getBaseInternshipList());
     }
 
     //// internship-level operations
@@ -98,17 +98,36 @@ public class WorkBook implements ReadOnlyWorkBook {
         internships.remove(key);
     }
 
+    /**
+     * Sorts list of internships by date
+     */
+    public void sortInternshipListByDate() {
+        internships.sortByDate();
+    }
+
+    /**
+     * Resets order of list
+     */
+    public void resetOrder() {
+        internships.resetOrder();
+    }
+
     //// util methods
 
     @Override
     public String toString() {
-        return internships.asUnmodifiableObservableList().size() + " internship applications";
+        return internships.asUnmodifiableBaseList().size() + " internship applications";
         // TODO: refine later
     }
 
     @Override
-    public ObservableList<Internship> getInternshipList() {
-        return internships.asUnmodifiableObservableList();
+    public ObservableList<Internship> getUiFacingInternshipList() {
+        return internships.asUiFacingUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Internship> getBaseInternshipList() {
+        return internships.asUnmodifiableBaseList();
     }
 
     @Override

--- a/src/main/java/seedu/workbook/model/internship/DateTime.java
+++ b/src/main/java/seedu/workbook/model/internship/DateTime.java
@@ -58,6 +58,24 @@ public class DateTime {
         return true;
     }
 
+    /**
+     * Note that DateTimeParseException will be thrown if this is called on DateTime.EMPTY
+     */
+    public boolean isAfter(DateTime other) {
+        LocalDateTime thisDate = LocalDateTime.parse(this.value, dateFormatter);
+        LocalDateTime otherDate = LocalDateTime.parse(other.value, dateFormatter);
+        return thisDate.isAfter(otherDate);
+    }
+
+    /**
+     * Note that DateTimeParseException will be thrown if this is called on DateTime.EMPTY
+     */
+    public boolean isPast() {
+        LocalDateTime thisDate = LocalDateTime.parse(this.value, dateFormatter);
+        return LocalDateTime.now().isAfter(thisDate);
+    }
+
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/workbook/model/internship/InternshipComparator.java
+++ b/src/main/java/seedu/workbook/model/internship/InternshipComparator.java
@@ -1,0 +1,33 @@
+package seedu.workbook.model.internship;
+
+import java.util.Comparator;
+
+/**
+ * Comparator used for sorting the Internship list by Date.
+ */
+public class InternshipComparator implements Comparator<Internship> {
+
+    @Override
+    public int compare(Internship o1, Internship o2) {
+        DateTime o1DateTime = o1.getDateTime();
+        DateTime o2DateTime = o2.getDateTime();
+
+        if (o1DateTime.equals(DateTime.EMPTY_DATETIME)) {
+            return o2DateTime.equals(DateTime.EMPTY_DATETIME)
+                    ? 0
+                    : o2DateTime.isPast()
+                            ? -1
+                            : 1;
+        }
+
+        if (o1DateTime.isPast()) {
+            return o2DateTime.equals(DateTime.EMPTY_DATETIME) || !o1DateTime.isAfter(o2DateTime)
+                    ? 1
+                    : -1;
+        }
+
+        return o2DateTime.equals(DateTime.EMPTY_DATETIME) || o2DateTime.isAfter(o1DateTime)
+                ? -1
+                : 1;
+    }
+}

--- a/src/main/java/seedu/workbook/storage/JsonSerializableWorkBook.java
+++ b/src/main/java/seedu/workbook/storage/JsonSerializableWorkBook.java
@@ -33,13 +33,13 @@ class JsonSerializableWorkBook {
 
     /**
      * Converts a given {@code ReadOnlyWorkBook} into this class for Jackson use.
-     *
+     * Uses the **unsorted** internship list from `source`.
      * @param source future changes to this will not affect the created
      *               {@code JsonSerializableWorkBook}.
      */
     public JsonSerializableWorkBook(ReadOnlyWorkBook source) {
         internships.addAll(
-                source.getInternshipList().stream().map(JsonAdaptedInternship::new).collect(Collectors.toList()));
+                source.getBaseInternshipList().stream().map(JsonAdaptedInternship::new).collect(Collectors.toList()));
     }
 
     /**

--- a/src/test/java/seedu/workbook/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/workbook/logic/commands/AddCommandIntegrationTest.java
@@ -39,7 +39,7 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_duplicateInternship_throwsCommandException() {
-        Internship internshipInList = model.getWorkBook().getInternshipList().get(0);
+        Internship internshipInList = model.getWorkBook().getBaseInternshipList().get(0);
         assertCommandFailure(new AddCommand(internshipInList), model, AddCommand.MESSAGE_DUPLICATE_INTERNSHIP);
     }
 

--- a/src/test/java/seedu/workbook/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/workbook/logic/commands/AddCommandTest.java
@@ -154,6 +154,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public void sortInternshipListByDate() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void resetOrder() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean canUndoWorkBook() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/workbook/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/workbook/logic/commands/CommandTestUtil.java
@@ -138,6 +138,14 @@ public class CommandTestUtil {
     }
 
     /**
+     * Updates {@code model}'s filtered list to show none of the internships in the {@code model}'s work book.
+     */
+    public static void filterOutAllInternships(Model model) {
+        model.updateFilteredInternshipList(unused -> false);
+        assertEquals(0, model.getFilteredInternshipList().size());
+    }
+
+    /**
      * Deletes the first internship in {@code model}'s filtered list from {@code model}'s work book.
      */
     public static void deleteFirstInternship(Model model) {

--- a/src/test/java/seedu/workbook/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/workbook/logic/commands/DeleteCommandTest.java
@@ -71,7 +71,7 @@ public class DeleteCommandTest {
 
         Index outOfBoundIndex = INDEX_SECOND_INTERNSHIP;
         // ensures that outOfBoundIndex is still in bounds of work book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getWorkBook().getInternshipList().size());
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getWorkBook().getBaseInternshipList().size());
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 

--- a/src/test/java/seedu/workbook/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/workbook/logic/commands/EditCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.workbook.logic.commands.CommandTestUtil.VALID_COMPANY_BOB;
 import static seedu.workbook.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.workbook.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.workbook.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.workbook.logic.commands.CommandTestUtil.filterOutAllInternships;
 import static seedu.workbook.logic.commands.CommandTestUtil.showInternshipAtIndex;
 import static seedu.workbook.testutil.TypicalIndexes.INDEX_FIRST_INTERNSHIP;
 import static seedu.workbook.testutil.TypicalIndexes.INDEX_SECOND_INTERNSHIP;
@@ -99,6 +100,9 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new WorkBook(model.getWorkBook()), new UserPrefs());
         expectedModel.setInternship(model.getFilteredInternshipList().get(0), editedInternship);
+        // since `edit` does not reset filtering anymore, and we changed the Company
+        // name in this test case no internships should match the original predicate
+        filterOutAllInternships(expectedModel);
         expectedModel.commitWorkBook();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -118,7 +122,7 @@ public class EditCommandTest {
         showInternshipAtIndex(model, INDEX_FIRST_INTERNSHIP);
 
         // edit internship in filtered list into a duplicate in work book
-        Internship internshipInList = model.getWorkBook().getInternshipList()
+        Internship internshipInList = model.getWorkBook().getBaseInternshipList()
                 .get(INDEX_SECOND_INTERNSHIP.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_INTERNSHIP,
                 new EditInternshipDescriptorBuilder(internshipInList).build());
@@ -145,7 +149,7 @@ public class EditCommandTest {
         showInternshipAtIndex(model, INDEX_FIRST_INTERNSHIP);
         Index outOfBoundIndex = INDEX_SECOND_INTERNSHIP;
         // ensures that outOfBoundIndex is still in bounds of work book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getWorkBook().getInternshipList().size());
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getWorkBook().getBaseInternshipList().size());
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditInternshipDescriptorBuilder().withCompany(VALID_COMPANY_BOB).build());

--- a/src/test/java/seedu/workbook/model/WorkBookTest.java
+++ b/src/test/java/seedu/workbook/model/WorkBookTest.java
@@ -27,7 +27,7 @@ public class WorkBookTest {
 
     @Test
     public void constructor() {
-        assertEquals(Collections.emptyList(), workBook.getInternshipList());
+        assertEquals(Collections.emptyList(), workBook.getBaseInternshipList());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class WorkBookTest {
 
     @Test
     public void getInternshipList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> workBook.getInternshipList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> workBook.getBaseInternshipList().remove(0));
     }
 
     /**
@@ -93,7 +93,12 @@ public class WorkBookTest {
         }
 
         @Override
-        public ObservableList<Internship> getInternshipList() {
+        public ObservableList<Internship> getUiFacingInternshipList() {
+            return internships;
+        }
+
+        @Override
+        public ObservableList<Internship> getBaseInternshipList() {
             return internships;
         }
     }

--- a/src/test/java/seedu/workbook/model/internship/UniqueInternshipListTest.java
+++ b/src/test/java/seedu/workbook/model/internship/UniqueInternshipListTest.java
@@ -176,7 +176,7 @@ public class UniqueInternshipListTest {
     public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(
             UnsupportedOperationException.class,
-            () -> uniqueInternshipList.asUnmodifiableObservableList().remove(0)
+            () -> uniqueInternshipList.asUnmodifiableBaseList().remove(0)
         );
     }
     // CHECKSTYLE.ON: SeparatorWrap


### PR DESCRIPTION
Add sorting by date, as specified in the DG. https://ay2223s1-cs2103t-t10-3.github.io/tp/DeveloperGuide.html 

Would appreciate extensive limit testing to try and break this.
Also, my implementation changed as I tested the feature and tweaked it to how I felt it should be used. So do test it and leave comments if you think the flow is bad. _(You can add my fork as an upstream repo, then fetch and checkout to my branch aka jacobkwan/tp/add-sorting-by-date or smth like that)_

Some example flows:
List -> Sort -> List
List -> Sort -> Edit (should stay in Sort view) -> List
List -> Add a bunch of applications with same company name but diff **role and date** -> Find by that company -> Sort -> Edit etc 

and whatever you else you can think of :)


In terms of design, overview is given in the Commits themselves, but basically Sorting is implemented as a state that and the UI draws from two base InternshipLists. Most of this logic is in `UniqueInternshipList.java`